### PR TITLE
Fix #11 - Only rename the prepublish script so the postinstall script can still be run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,13 +61,17 @@ async function runPrepublishScript (pkgDir: string) {
 function hideDeps (pkgDir: string) {
   return renameKeys(pkgDir, {
     dependencies: '__dependencies',
-    scripts: '__scripts'
+    scripts: {
+      prepublish: '__prepublish'
+    }
   })
 }
 
 function unhideDeps (pkgDir: string) {
   return renameKeys(pkgDir, {
     __dependencies: 'dependencies',
-    __scripts: 'scripts'
+    scripts: {
+      __prepublish: 'prepublish'
+    }
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,8 @@ function hideDeps (pkgDir: string) {
   return renameKeys(pkgDir, {
     dependencies: '__dependencies',
     scripts: {
-      prepublish: '__prepublish'
+      prepublish: '__prepublish',
+      prepublishOnly: '__prepublishOnly'
     }
   })
 }
@@ -71,7 +72,8 @@ function unhideDeps (pkgDir: string) {
   return renameKeys(pkgDir, {
     __dependencies: 'dependencies',
     scripts: {
-      __prepublish: 'prepublish'
+      __prepublish: 'prepublish',
+      __prepublishOnly: 'prepublishOnly'
     }
   })
 }

--- a/src/renameKeys.ts
+++ b/src/renameKeys.ts
@@ -5,15 +5,22 @@ import path = require('path')
 export default async (pkgDir: string, keysMap: Object) => {
   const pkgJSON = await readPkg(pkgDir, {normalize: false})
 
-  const newPkgJSON = {}
-  const keys = Object.keys(pkgJSON)
-  for (let i = 0; i < keys.length; i++) {
-    if (keysMap[keys[i]]) {
-      newPkgJSON[keysMap[keys[i]]] = pkgJSON[keys[i]]
-      continue
-    }
-    newPkgJSON[keys[i]] = pkgJSON[keys[i]]
-  }
+  const newPkgJSON = renameKeys(pkgJSON, keysMap);
 
   await writePkg(pkgDir, newPkgJSON)
+}
+
+function renameKeys(target: Object, keysMap: Object): Object {
+  const copy = {}
+  for (let key of Object.keys(target)) {
+    if (typeof keysMap[key] === 'string') {
+      copy[keysMap[key]] = target[key]
+    } else if (typeof keysMap[key] === 'object') {
+      copy[key] = renameKeys(target[key], keysMap[key])
+    } else {
+      copy[key] = target[key]
+    }
+  }
+
+  return copy
 }


### PR DESCRIPTION
How does this look?